### PR TITLE
add assert_fail(msg, ...) for manual failures

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -31,6 +31,7 @@
 - `assert_not_equal(a, b)`
 - `assert_str_equal(a, b)`
 - `assert_str_not_equal(a, b)`
+- `assert_fail(msg, ...)`
 
 ## Example
 

--- a/assertion-macros.h
+++ b/assertion-macros.h
@@ -172,4 +172,21 @@ static int __assert_failures = 0;
   }                                                             \
 } while(0);
 
+/*
+ * Assert failure `msg`
+ */
+
+#define assert_fail(msg, ...) do {                            \
+  __assert_failures++;                                        \
+  fprintf(stderr, "Assertion error: ");                       \
+  fprintf(stderr, msg, ##__VA_ARGS__);                        \
+  fprintf(                                                    \
+      stderr                                                  \
+    , " (%s:%d)\n"                                            \
+    , __FILE__                                                \
+    , __LINE__                                                \
+  );                                                          \
+  if (__assert_bail) abort();                                 \
+} while(0);
+
 #endif


### PR DESCRIPTION
useful for test-case loops where a static message is not enough. Might be nicer to just make them all variadic but I'm lazyyyyy